### PR TITLE
fix: Alfred 5 Powerpack features not working (#50)

### DIFF
--- a/script/apps.json
+++ b/script/apps.json
@@ -107,7 +107,8 @@
             "app_path": "/Applications/$app_name.app",
             "app_bin_path": "$app_path/Contents/MacOS/$app_name",
             "inject_type": "static",
-            "inject_path": "$app_path/Contents/Preferences/Alfred Preferences.app/Contents/MacOS/Alfred Preferences"
+            "inject_path": "$app_path/Contents/MacOS/Alfred",
+            "post_script": "sudo bash apps/alfred_hack.sh"
         },
         {
             "app_name": "Navicat Premium",

--- a/script/apps/alfred_hack.sh
+++ b/script/apps/alfred_hack.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+insert_dylib="$PWD/../tools/insert_dylib"
+app_name="Alfred 5"
+app_path="/Applications/${app_name}.app"
+preferences_bin="${app_path}/Contents/Preferences/Alfred Preferences.app/Contents/MacOS/Alfred Preferences"
+
+echo -e "${GREEN}✅ [${app_name}] - Injecting dylib into Alfred Preferences...${NC}"
+sudo "$insert_dylib" --inplace --weak --all-yes --no-strip-codesig '@rpath/libdylib_dobby_hook.dylib' "$preferences_bin"
+
+echo -e "${GREEN}✅ [${app_name}] - Re-signing Alfred Preferences...${NC}"
+sudo codesign -f -s - --all-architectures --deep "$preferences_bin"


### PR DESCRIPTION
Inject dylib into both main Alfred binary and Preferences binary. Previously only Preferences was injected, so Powerpack features (Clipboard, Snippets, etc.) controlled by the main process were not activated.

- Change inject_path to main binary (Alfred)
- Add post_script to inject and re-sign Preferences binary separately
- Add alfred_hack.sh for Preferences injection and codesign